### PR TITLE
Handle mkdir() race conditions

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -321,7 +321,12 @@ def mktime(timestamp):
 
 def mkdir(folder):
     if not os.path.exists(folder):
-        os.makedirs(folder)
+        try:
+            os.makedirs(folder)
+        except OSError as err:
+            # Ignore rare 'File exists' race conditions.
+            if err.errno != 17:
+                raise
 
 
 def ensure_readable(file_path, default_perms=None):


### PR DESCRIPTION
I've ran into a 'File exists' OSError a few times on the os.makedirs() call and this should take care of this unlikely but possible case.

**Please refer to the contribution guidelines in the README when submitting PRs.**
